### PR TITLE
Setup blog for redirects & rewrites

### DIFF
--- a/components/NotionPage.tsx
+++ b/components/NotionPage.tsx
@@ -140,6 +140,20 @@ const propertyTextValue = (
   return defaultFn()
 }
 
+function PageLink(
+  props: React.DetailedHTMLProps<
+    React.AnchorHTMLAttributes<HTMLAnchorElement>,
+    HTMLAnchorElement
+  >
+) {
+  return (
+    <a
+      {...props}
+      href={props.href.startsWith('/blog') ? props.href : `/blog${props.href}`}
+    />
+  )
+}
+
 export const NotionPage: React.FC<types.PageProps> = ({
   site,
   recordMap,
@@ -153,6 +167,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
     () => ({
       nextImage: Image,
       nextLink: Link,
+      PageLink,
       Code,
       Collection,
       Equation,
@@ -258,7 +273,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
       <NewsArticleJsonLd
         url={canonicalPageUrl}
         title={title}
-        images={['https://bask.blog/favicon_bask_round.png']}
+        images={['https://bask.health/blog/favicon_bask_round.png']}
         datePublished={new Date(getSocial('Published'))?.toString()}
         dateCreated={new Date(getSocial('Created'))?.toString()}
         dateModified={new Date(getSocial('Last Updated'))?.toString()}
@@ -267,7 +282,7 @@ export const NotionPage: React.FC<types.PageProps> = ({
         keywords={postKeywords}
         authorName={getSocial('Author') || config.author}
         publisherName='Bask Health'
-        publisherLogo='https://bask.blog/favicon_bask_round.png'
+        publisherLogo='https://bask.health/blog/favicon_bask_round.png'
         description={socialDescription}
         body={socialDescription}
       />
@@ -298,7 +313,6 @@ export const NotionPage: React.FC<types.PageProps> = ({
         pageAside={pageAside}
         footer={footer}
       />
-
     </>
   )
 }

--- a/next.config.js
+++ b/next.config.js
@@ -19,5 +19,20 @@ module.exports = withBundleAnalyzer({
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;"
   },
-  basePath: '/blog'
+  basePath: '/blog',
+  async redirects() {
+    const sources = ['/', '/:path']
+    return sources.map((s) => ({
+      source: s,
+      destination: `${process.env.ROOT_URL}/blog${s === '/' ? '' : s}`,
+      has: [
+        {
+          type: 'host',
+          value: process.env.REDIRECT_DOMAIN || 'bask.blog'
+        }
+      ],
+      permanent: false,
+      basePath: false
+    }))
+  }
 })

--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,9 @@ module.exports = withBundleAnalyzer({
     const sources = ['/', '/:path']
     return sources.map((s) => ({
       source: s,
-      destination: `${process.env.ROOT_URL}/blog${s === '/' ? '' : s}`,
+      destination: `${process.env.ROOT_URL || 'https://bask.health'}/blog${
+        s === '/' ? '' : s
+      }`,
       has: [
         {
           type: 'host',

--- a/next.config.js
+++ b/next.config.js
@@ -18,5 +18,6 @@ module.exports = withBundleAnalyzer({
     formats: ['image/avif', 'image/webp'],
     dangerouslyAllowSVG: true,
     contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;"
-  }
+  },
+  basePath: '/blog'
 })

--- a/site.config.ts
+++ b/site.config.ts
@@ -10,11 +10,12 @@ export default siteConfig({
 
   // basic site info (required)
   name: 'Bask Health | Blog',
-  domain: 'bask.blog',
+  domain: 'bask.health',
   author: 'Bask Health, Inc',
 
   // open graph metadata (optional)
-  description: 'Our completely customizable platform allows you to expand your healthcare business online. From our white label solution to our suite of telehealth APIs. We offer the no-code tools to build your DTC telehealth brand.	',
+  description:
+    'Our completely customizable platform allows you to expand your healthcare business online. From our white label solution to our suite of telehealth APIs. We offer the no-code tools to build your DTC telehealth brand.	',
 
   // social usernames (optional)
   twitter: 'baskhealth',


### PR DESCRIPTION
Set up the branch to redirect all requests on the domain `REDIRECT_DOMAIN` (defaults to `bask.blog`) to `${ROOT_URL}/blog` (`ROOT_URL` defaults to `https://bask.health`)

Setting up a temporary redirect for now (302) as soon as we push it live and we know it works we can deploy a patch with the permanent (301) to avoid people linked permanently to some broken link if something doesn't work as expected. 

The other repo (host of `ROOT_URL`), will rewrite all the requests to this app, but the URL used in the rewrite mustn't be set to the same as `REDIRECT_DOMAIN` to prevent a redirection loop from closing. 